### PR TITLE
Compile Nil to NULL

### DIFF
--- a/test/clojureql/core_test.clj
+++ b/test/clojureql/core_test.clj
@@ -27,7 +27,7 @@
          (-> (table {} :users)
              (select (where (= :id nil)))
              to-sql)
-         "SELECT users.* FROM users WHERE (id = NULL)"
+         "SELECT users.* FROM users WHERE (id IS NULL)"
          (-> (table {} :users)
              (select (where (or (= :id 5) (>= :id 10))))
              (project [:id])

--- a/test/clojureql/test/predicates.clj
+++ b/test/clojureql/test/predicates.clj
@@ -1,0 +1,26 @@
+(ns clojureql.test.predicates
+  (:use clojureql.predicates clojure.test))
+
+(deftest test-compile-expr
+  (are [expression result]
+    (is (= result (compile-expr expression)))
+    [:eq :id 5]
+    "(id = 5)"
+    [:eq :id nil]
+    "(id IS NULL)"
+    [:eq nil :id]
+    "(id IS NULL)"
+    [:eq nil nil]
+    "(NULL IS NULL)"))
+
+(deftest test-sanitize-expr
+  (are [expression result]
+    (is (= result (sanitize-expr expression)))
+    [:eq :id 5]
+    '("id" 5)
+    [:eq :id nil]
+    '("id" "NULL")
+    [:eq nil :id]
+    '("NULL" "id")
+    [:eq nil nil]
+    '("NULL" "NULL")))


### PR DESCRIPTION
Hi Lau & Ninjudd,

I added a small fix to handle nil in the compile-expr function. Before that change the following form 

```
(-> (table {} :users) (select (where (= :id nil))) to-sql)
```

was generating 

```
SELECT users.* FROM users WHERE (id = )
```

Now it will generate 

```
SELECT users.* FROM users WHERE (id = NULL)
```

Roman.
