### PR TITLE
The update-in! fn generates  "(id IS 'NULL')" instead of "(id IS NULL)".

### DIFF
--- a/src/clojureql/core.clj
+++ b/src/clojureql/core.clj
@@ -259,7 +259,6 @@
                        (when offset         (str "OFFSET " offset))])
         env       (->> [(map (comp :env last) jdata) (when preds [(:env preds)])]
                        flatten vec
-                       (remove nil?)
                        vec)
         sql-vec   (into [statement] env)]
     (when *debug* (prn sql-vec))
@@ -267,7 +266,7 @@
 
 (defn interpolate-sql [[stmt & args]]
   "For compilation test purposes only"
-  (reduce #(.replaceFirst %1 "\\?" (str %2)) stmt args))
+  (reduce #(.replaceFirst %1 "\\?" (if (nil? %2) "NULL" (str %2))) stmt args))
 
 
                                         ; RELATIONAL ALGEBRA

--- a/src/clojureql/predicates.clj
+++ b/src/clojureql/predicates.clj
@@ -4,11 +4,7 @@
         [clojure.string :only [join] :rename {join join-str}]))
 
 (defn sanitize [expression]
-  (reduce #(conj %1
-                 (cond (string? %2)      %2
-                       (nil? %2)         "NULL"
-                       :else %2)) []
-      (remove keyword? expression)))
+  (reduce #(conj %1 %2) [] (remove keyword? expression)))
 
 (defn parameterize [op expression]
   (str "("

--- a/test/clojureql/predicates_test.clj
+++ b/test/clojureql/predicates_test.clj
@@ -6,8 +6,8 @@
        (=* :id 5)
        ["(id = ?)" [5]]
        (=* :id nil)
-       ["(id IS ?)" ["NULL"]]
+       ["(id IS ?)" [nil]]
        (=* nil :id)
-       ["(id IS ?)" ["NULL"]]
+       ["(id IS ?)" [nil]]
        (=* nil nil)
        ["TRUE" []]))


### PR DESCRIPTION
Hi Lau,

I'm trying to use the beta 2 version of clojureql for some of my
queries. Just found a bug that was caused by the update-in! fn
when using nil values. The fn was generating "(id IS 'NULL')"
instead of "(id IS NULL)". This was not caused by the fn
itself. With the parameterization of args the sanitize fn should
not handle the conversion of nil values anymore, because
otherwise it would be double escapes (or converted). I fixed this
and added some tests. I think the same applies when compiling (=*
nil nil) => ["TRUE" []]). I think it should be [true []], but I
have to check this later ...

Greetings, Roman.
