### PR TITLE
Added `not-like` predicate

### DIFF
--- a/src/clojureql/predicates.clj
+++ b/src/clojureql/predicates.clj
@@ -11,7 +11,7 @@
             (map #(if (keyword? %)
                     (str (to-tablename %))
                     "?"))
-            (join-str (str \space op \space)))
+            (join-str (str \space (.replace (str op) "-" " ") \space)))
        ")"))
 
 (defprotocol Predicate
@@ -83,14 +83,12 @@
     (spec-op (predicate) (into ["IS NOT"] args))
     (infix (predicate) "!=" args)))
 
-(defn not-like [& args]
-  (infix (predicate) "NOT LIKE" args))
-
-(defoperator like :like  "LIKE operator:  (like :x \"%y%\"")
-(defoperator >*   :>     "> operator:     (> :x 5)")
-(defoperator <*   :<     "< operator:     (< :x 5)")
-(defoperator <=*  :<=    "<= operator:    (<= :x 5)")
-(defoperator >=*  :>=    ">= operator:    (>= :x 5)")
+(defoperator like     :like     "LIKE operator:      (like :x \"%y%\"")
+(defoperator not-like :not-like "NOT LIKE operator:  (not-like :x \"%y%\"")
+(defoperator >*       :>        "> operator:         (> :x 5)")
+(defoperator <*       :<        "< operator:         (< :x 5)")
+(defoperator <=*      :<=       "<= operator:        (<= :x 5)")
+(defoperator >=*      :>=       ">= operator:        (>= :x 5)")
 
 (defn restrict
   "Returns a query string.

--- a/test/clojureql/test/predicates.clj
+++ b/test/clojureql/test/predicates.clj
@@ -1,6 +1,11 @@
 (ns clojureql.test.predicates
   (:use clojureql.predicates clojure.test))
 
+(deftest test-parameterize
+  (are [op expression result] (= result (parameterize op expression))
+       :like '(:x "foo%") "(x :like ?)"
+       :not-like '(:y "bar%") "(y :not like ?)"))
+
 (deftest test-compile-expr
   (are [expression result] (= result ((juxt str :env) expression))
        (=* :id 5)


### PR DESCRIPTION
Added `not-like` predicate as a convenience method. Decided to go with `not-like` instead of `!like`, which is closer to `!=`, since the final (SQL) syntax is `NOT LIKE`.

-ck

Disclaimer: I do not claim nor pretend to be a particular good programmer, never mind Clojure programmer, hence review the submitted code carefully.
