### PR TITLE
Doc fix

### DIFF
--- a/src/clojureql/core.clj
+++ b/src/clojureql/core.clj
@@ -145,7 +145,7 @@
    via the name supplies as results.
 
   Example:
-   (with-results table res
+   (with-results [res table]
      (println res))"
   [[results tble] & body]
   `(apply-on ~tble (fn [~results] ~@body)))


### PR DESCRIPTION
Fixed the doc string for with-results.
README already contains correct call.

-ck
