### PR TITLE
Fix position of ORDER BY clauses

### DIFF
--- a/src/clojureql/core.clj
+++ b/src/clojureql/core.clj
@@ -251,11 +251,12 @@
         statement (clean-sql ["SELECT" fields
                        (when tables "FROM") tables
                        (when preds "WHERE") (str preds)
-                       (when (seq order-by) (str "ORDER BY " (to-orderlist tname order-by)))
+                       
                        (when grouped-by     (str "GROUP BY " (to-fieldlist tname grouped-by)))
                        (when limit          (str "LIMIT " limit))
                        (when offset         (str "OFFSET " offset))
-                       (when combination    (str (combination-op (:combination tble)) \space (first combination)))])
+                       (when combination    (str (combination-op (:combination tble)) \space (first combination)))
+                       (when (seq order-by) (str "ORDER BY " (to-orderlist tname order-by)))])
         env       (concat
                    (->> [(map (comp :env last) jdata) (if preds [(:env preds)])]
                         flatten (remove nil?) vec)

--- a/test/clojureql/test/core.clj
+++ b/test/clojureql/test/core.clj
@@ -187,4 +187,10 @@
              (union (select (table :users) (where (<= :id 3))) :distinct))
          "SELECT users.* FROM users WHERE (id >= 0) EXCEPT ALL SELECT users.* FROM users WHERE (id = 1) INTERSECT SELECT users.* FROM users WHERE (id = 2) UNION DISTINCT SELECT users.* FROM users WHERE (id <= 3)"))
 
+  (testing "union with sorting"
+    (are [x y] (= (-> x (compile nil) interpolate-sql) y)
+         (-> (table :t1)
+             (union (table :t2))
+             (sort [:col1, :col2]))
+         "SELECT t1.* FROM t1 UNION SELECT t2.* FROM t2 ORDER BY col1 asc,col2 asc"))
   )


### PR DESCRIPTION
Was just bit by this while trying to do a 'sort' on a relation like (difference r1 r2). 
Moved the insertion of order-by clauses to the end of the complete query expression.
-ryan
