### PR TITLE
Added the default global connection feature.

### DIFF
--- a/src/clojureql/core.clj
+++ b/src/clojureql/core.clj
@@ -26,23 +26,30 @@
 
                                         ; CONNECTIVITY
 
-(defn open-global [id specs]
-  (let [con (sqlint/get-connection specs)]
+(defn open-global
+  "Opens a global connection with the supplied specs. If given a
+  conn-name, use it as a key to access that connection, else set the
+  default global connection."
+  [specs & [conn-name]]
+  (let [con (sqlint/get-connection specs)
+        conn-name (or conn-name ::default-connection)]
     (when-let [ac (-> specs :auto-commit)]
       (.setAutoCommit con ac))
-    (swap! global-connections assoc id {:connection con :opts specs})))
+    (swap! global-connections assoc conn-name {:connection con :opts specs})))
 
 (defn close-global
   "Supplied with a keyword identifying a global connection, that connection
-  is closed and the reference dropped."
-  [conn-name]
-  (if-let [conn (conn-name @global-connections)]
-    (do
-      (.close (:connection conn))
-      (swap! global-connections dissoc conn-name)
-      true)
-    (throw
-     (Exception. (format "No global connection by that name is open (%s)" conn-name)))))
+  is closed and the reference dropped. "
+  [& [conn-name]]
+  (let [conn-name (or conn-name ::default-connection)]
+    (if-let [conn (conn-name @global-connections)]
+      (do
+        (.close (:connection conn))
+        (swap! global-connections dissoc conn-name)
+        true)
+      (throw
+       (Exception.
+        (format "No global connection by that name is open (%s)" conn-name))))))
 
 (defmacro with-cnx
   "For internal use only. If you want to wrap a query in a connection, use
@@ -55,26 +62,27 @@
   closes the connection."
   [con-info func]
   (io!
-   (if (keyword? con-info)
-     (if-let [con (@clojureql.core/global-connections con-info)]
-       (binding [sqlint/*db*
-                 (assoc sqlint/*db*
-                   :connection (:connection con)
-                   :level 0
-                   :rollback (atom false)
-                   :opts     (:opts con))]
-         (func))
-       (throw
-        (Exception. "No such global connection currently open!")))
-     (with-open [con (sqlint/get-connection con-info)]
-       (binding [sqlint/*db*
-                 (assoc sqlint/*db*
-                   :connection con
-                   :level 0
-                   :rollback (atom false)
-                   :opts     con-info)]
-         (.setAutoCommit con (or (-> con-info :auto-commit) true))
-         (func))))))
+  (let [con-info (or con-info ::default-connection)]
+    (if (keyword? con-info)
+      (if-let [con (@clojureql.core/global-connections con-info)]
+        (binding [sqlint/*db*
+                  (assoc sqlint/*db*
+                    :connection (:connection con)
+                    :level 0
+                    :rollback (atom false)
+                    :opts     (:opts con))]
+          (func))
+        (throw
+         (Exception. "No such global connection currently open!")))
+      (with-open [con (sqlint/get-connection con-info)]
+        (binding [sqlint/*db*
+                  (assoc sqlint/*db*
+                    :connection con
+                    :level 0
+                    :rollback (atom false)
+                    :opts     con-info)]
+          (.setAutoCommit con (or (-> con-info :auto-commit) true))
+          (func)))))))
 
                                        ; INTERFACES
 

--- a/src/clojureql/internal.clj
+++ b/src/clojureql/internal.clj
@@ -294,7 +294,9 @@
    constructing a table, and instead wrapping their calls in
    with-connection"
   [& body]
-  `(if ~'cnx
+  `(if (or ~'cnx
+           (contains? @clojureql.core/global-connections
+                      ::clojureql.core/default-connection))
      (clojureql.core/with-cnx ~'cnx (do ~@body))
      (do ~@body)))
 


### PR DESCRIPTION
Hi, here's a small change to add the default global connection feature. The only interface changes are making optional the conn-name argument of open-global and close-global. I've also reversed the order of arguments for open-global to keep the code minimal.
