### PR TITLE
Here's a fixed and improved version of the default global connection feature.

### DIFF
--- a/src/clojureql/core.clj
+++ b/src/clojureql/core.clj
@@ -168,7 +168,8 @@
                    combinations]
   clojure.lang.IDeref
   (deref [this]
-    (if cnx
+    (if (or cnx (contains? @clojureql.core/global-connections
+                           ::clojureql.core/default-connection))
       (apply-on this doall)
       (throw (Exception. "No database connection is associated with this table"))))
 

--- a/src/clojureql/internal.clj
+++ b/src/clojureql/internal.clj
@@ -264,7 +264,9 @@
    constructing a table, and instead wrapping their calls in
    with-connection"
   [& body]
-  `(if ~'cnx
+  `(if (or ~'cnx
+           (contains? @clojureql.core/global-connections
+                      ::clojureql.core/default-connection))
      (clojureql.core/with-cnx ~'cnx (do ~@body))
      (do ~@body)))
 


### PR DESCRIPTION
I've fixed some issues with recent code changes and made open-global keep its arguments order.
