### PR TITLE
Makes all tests run if cake isn't available

### DIFF
--- a/test/clojureql/test.clj
+++ b/test/clojureql/test.clj
@@ -2,8 +2,12 @@
   (:refer-clojure :exclude [compile drop take sort distinct conj! disj!])
   (:use clojure.contrib.sql
         clojure.test
-        clojureql.core
-        [cake :only [*opts*]]))
+        clojureql.core))
+
+(try 
+  (use '[cake :only [*opts*]])
+  (catch Exception _
+    (def *opts* {:integration true})))
 
 (when (:show-sql *opts*)
   (alter-var-root #'clojureql.core/*debug* (constantly true)))


### PR DESCRIPTION
I'm still using Leiningen on my main dev machine, so I'd rather make all tests run instead of skipping the integration tests.
