### PR TITLE
Fixed small issue with default global connection feature

### DIFF
--- a/src/clojureql/connectivity.clj
+++ b/src/clojureql/connectivity.clj
@@ -6,7 +6,7 @@
   "Opens a global connection with the supplied specs. If given a
   conn-name, use it as a key to access that connection, else set the
   default global connection."
-  ([specs] (open-global ::default-connection specs))
+  ([specs] (open-global ::clojureql.internal/default-connection specs))
   ([conn-name specs]
      (let [con (sqlint/get-connection specs)]
        (when-let [ac (-> specs :auto-commit)]
@@ -18,7 +18,7 @@
   connection is closed and the reference dropped. When called without
   argument, close the default global connection."
   [& [conn-name]]
-  (let [conn-name (or conn-name ::default-connection)]
+  (let [conn-name (or conn-name ::clojureql.internal/default-connection)]
     (if-let [conn (conn-name @global-connections)]
       (do
         (.close (:connection conn))
@@ -39,7 +39,7 @@
   closes the connection."
   [con-info func]
   (io!
-  (let [con-info (or con-info ::default-connection)]
+  (let [con-info (or con-info ::clojureql.internal/default-connection)]
     (if (keyword? con-info)
       (if-let [con (@clojureql.core/global-connections con-info)]
         (binding [sqlint/*db*

--- a/src/clojureql/internal.clj
+++ b/src/clojureql/internal.clj
@@ -286,7 +286,7 @@
   [& body]
   `(if (or ~'cnx
            (contains? @clojureql.core/global-connections
-                      ::clojureql.core/default-connection))
+                      ::default-connection))
      (clojureql.core/with-cnx ~'cnx (do ~@body))
      (do ~@body)))
 


### PR DESCRIPTION
I just realized I made a small mistake in the design of the default global connection feature. I made the ::default-connection a keyword of the core namespace, but that break modularity. I've changed it to be owned by the internal namespace so that we can refer to internal and predicates namespaces independently.
