### PR TITLE
Cleanup and better error messages for connection-lookup

### DIFF
--- a/src/clojureql/core.clj
+++ b/src/clojureql/core.clj
@@ -173,8 +173,8 @@
 
   Relation
   (apply-on [this f]
-    (in-connection*
-     (with-results* (compile this cnx) f)))
+    (with-cnx cnx
+      (with-results* (compile this cnx) f)))
 
   (pick! [this kw]
     (let [results @this]
@@ -265,21 +265,21 @@
         table)))
 
   (conj! [this records]
-     (in-connection*
+     (with-cnx cnx
       (if (map? records)
         (insert-records tname records)
         (apply insert-records tname records)))
      this)
 
   (disj! [this predicate]
-     (in-connection*
+     (with-cnx cnx
        (delete-rows tname (into [(str predicate)] (:env predicate))))
     this)
 
   (update-in! [this pred records]
     (let [predicate (into [(str pred)] (:env pred))]
       (when *debug* (prn predicate))
-      (in-connection*
+      (with-cnx cnx
        (if (map? records)
          (update-or-insert-vals tname predicate records)
          (apply update-or-insert-vals tname predicate records)))

--- a/src/clojureql/internal.clj
+++ b/src/clojureql/internal.clj
@@ -277,19 +277,6 @@
 
                                         ; SQL Specifics
 
-(defmacro in-connection*
-  "For internal use only!
-
-   This lets users supply a nil argument as the connection when
-   constructing a table, and instead wrapping their calls in
-   with-connection"
-  [& body]
-  `(if (or ~'cnx
-           (contains? @clojureql.core/global-connections
-                      ::default-connection))
-     (clojureql.core/with-cnx ~'cnx (do ~@body))
-     (do ~@body)))
-
 (defn result-seq
   "Creates and returns a lazy sequence of structmaps corresponding to
   the rows in the java.sql.ResultSet rs. Accepts duplicate keys"


### PR DESCRIPTION
Commit msg pretty much explains it.

Be aware, that behavior _might_ have changed in some corner cases, such as some combinations of c.c.sql/with-connection, global connections, and table connections. But it's now clearly visible and tested.
