### PR TITLE
Fixed like predicate

### DIFF
--- a/src/clojureql/core.clj
+++ b/src/clojureql/core.clj
@@ -49,6 +49,7 @@
     and  clojureql.predicates/and*
     or   clojureql.predicates/or*
     not  clojureql.predicates/not*
+    like clojureql.predicates/like
     nil? clojureql.predicates/nil?*
     in   clojureql.predicates/in})
 


### PR DESCRIPTION
Queries using the like predicate weren't working because it hadn't been added to the predicate-symbols map in clojureql.core.  This patch fixes that issue.
