### PR TITLE
autogenerated keys

### DIFF
--- a/src/clojureql/internal.clj
+++ b/src/clojureql/internal.clj
@@ -356,7 +356,7 @@
   open database connection. Each param-group is a seq of values for all of
   the parameters."
   [sql & param-groups]
-  (with-open [stmt (.prepareStatement (:connection sqlint/*db*) sql)]
+  (with-open [stmt (.prepareStatement (:connection sqlint/*db*) sql java.sql.Statement/RETURN_GENERATED_KEYS)]
     (doseq [param-group param-groups]
       (doseq [[idx v] (map vector (iterate inc 1) param-group)]
         (.setObject stmt idx v))


### PR DESCRIPTION
Higher version numbers of the odbc driver for mysql require that statement preparation sets a flag indicating that autogenerated keys will be requested. 
