### PR TITLE
Associative fix

### DIFF
--- a/src/clojureql/core.clj
+++ b/src/clojureql/core.clj
@@ -229,19 +229,23 @@
 
   (outer-join [this table2 type join-on]
 	      (let [sort-joins (fn sort-joins [joins]
-				 (reduce (fn insert-join [lst {[table-name join-on] :data :as join}]
-					   (if (-> lst count (< 2))
-					     (conj lst join)
-					     (let [to-t-name (fn to-t-name [l] (-> l :data first))
-						   required-tables (->> join-on :cols (map #(-> % name (.replaceAll "\\..*" ""))))
-						   {:keys [pos]} (reduce (fn find-fn [m {[el] :data :as join}]
-									   (if (:found m)
-									     m
-									     {:pos (inc (:pos m 0))
-									      :found (-> m :list (or #{}) (some required-tables))
-									      :list (conj (:list m #{}) el)})) {} lst)]
-					       (concat (clojure.core/take pos lst) [join] (clojure.core/drop pos lst)))))
-					 [] joins))
+				 (let [to-tbl-name (fn to-tbl-name [{[table-name join-on] :data :as join}]
+						     (->> join-on :cols
+							  (map #(-> % name (.replaceAll "\\..*" "")))
+							  (filter #(not= % table-name))
+							  first))
+				       to-graph-el (fn to-graph-el [m {[table-name join-on] :data :as join}]
+						     (let [required-table (to-tbl-name join)]
+						       (assoc m table-name required-table)))
+				       map-of-joins (reduce #(let [{[table-name join-on] :data :as join} %2
+								   k table-name]
+							       (assoc %1 k (conj (%1 k) join))) {} joins)
+				       edges (reduce to-graph-el {} joins)
+				       set-of-root-nodes (clojure.set/difference (into #{} (vals edges)) (into #{} (keys edges)))
+				       add-deps (fn add-deps [tbl]
+						  (into [(map-of-joins tbl)] (map add-deps (filter #(= tbl (edges %)) (keys edges)))))
+				       sorted-joins (filter #(not (nil? %)) (flatten (map add-deps set-of-root-nodes)))]
+				   sorted-joins))
 		    j (into (or joins []) (-> table2 :joins (or [])))]
 		(if (requires-subselect? table2)
 		  (assoc this

--- a/test/clojureql/test/core.clj
+++ b/test/clojureql/test/core.clj
@@ -257,7 +257,7 @@
 	  tb (join (table :t3) ta :id)] ;; swapping argument order of "ta" and "(table :t3)" works
       (are [x y] (= (-> x (compile nil) interpolate-sql (.replaceAll "SELECT .* FROM" "SELECT * FROM")) y)
 	   tb
-	   "SELECT * FROM t3 JOIN t2 USING(id) JOIN t1 USING(id)"))
+	   "SELECT * FROM t3 JOIN t1 USING(id) JOIN t2 USING(id)"))
     (let [ta (-> (table :t1)
 		 (join (table :t2) (where (= :t1.a :t2.a)))
 		 (join (table :t6) (where (= :t6.e :t2.e))))
@@ -272,7 +272,69 @@
 		"JOIN t6 ON (t6.e = t2.e) "
 		"JOIN t3 ON (t3.c = t2.c) "
 		"JOIN t4 ON (t3.b = t4.b) "
-		"JOIN t5 ON (t5.d = t4.d)"))))
+		"JOIN t5 ON (t5.d = t4.d)")))
+    (let [product-variants-table (project (table :product_variants)
+					      [[:id			:as :product_variant_id]
+					       [:product_id		:as :product_variant_product_id]
+					       [:product_code		:as :product_variant_product_code]
+					       [:status			:as :product_variant_status]
+					       [:price_id		:as :product_variant_price_id]])
+	  products-table (project (table :products)
+				      [[:id				:as :product_id]
+				       [:name				:as :product_name]
+				       [:description			:as :product_description]
+				       [:manufacturer_id		:as :product_manufacturer_id]])
+	  product-variant-skus-table (project (table :product_variant_skus)
+						  [[:id			:as :product_variant_sku_id]
+						   [:product_variant_id	:as :product_variant_sku_product_variant_id]
+						   [:sku_id		:as :product_variant_sku_sku_id]
+						   [:quantity		:as :product_variant_sku_quantity]])
+	  orders-table   (project (table :orders)
+				      [[:id				:as :order_id]
+				       [:customer_id			:as :order_customer_id]
+				       [:customer_ref			:as :order_customer_ref]
+				       [:created			:as :order_created]
+				       [:status				:as :order_status]
+				       [:created_by			:as :order_created_by]
+				       [:source_id			:as :order_source_id]
+				       [:updated			:as :order_updated]
+				       [:cancellation_reason_id		:as :order_cancellation_reason_id]
+				       [:expirable			:as :order_expirable]
+				       [:shipping_method_id		:as :order_shipping_method_id]])
+	  order-lines-table (project (table :order_lines)
+					 [[:id				:as :order_line_id]
+					  [:order_id			:as :order_line_order_id]
+					  [:product_variant_id		:as :order_line_product_variant_id]
+					  [:quantity			:as :order_line_quantity]
+					  [:status			:as :order_line_status]
+					  [:updated			:as :order_line_updated]
+					  [:price_id			:as :order_line_price_id]
+					  [:shippable_estimate		:as :order_line_shippable_estimate]])
+	  orders-with-lines-query (-> orders-table
+				      (join order-lines-table (where (= :orders.id :order_lines.order_id))))
+	  sku-table (project (table :skus) [[:id		:as :sku_id]
+						    [:stock_code	:as :sku_stock_code]
+						    [:barcode		:as :sku_barcode]
+						    [:reorder_quantity	:as :sku_reorder_quantity]
+						    [:minimum_level	:as :sku_minimum_level]])
+	  products-with-skus-query (-> product-variants-table
+				       (join products-table (where (= :products.id :product_variants.product_id)))
+				       (join product-variant-skus-table (where (= :product_variants.id :product_variant_skus.product_variant_id)))
+				       (join sku-table (where (= :skus.id :product_variant_skus.sku_id))))
+	  orders-with-skus-query (-> orders-with-lines-query
+				     (join products-with-skus-query
+					       (where (= :order_lines.product_variant_id :product_variants.id))))
+	  open-orders-with-skus-query  (-> orders-with-skus-query
+					   (select (where (= :orders.status 1))))]
+      (are [x y] (= (-> x (compile nil) interpolate-sql (.replaceAll "SELECT .* FROM" "SELECT * FROM")) y)
+	   open-orders-with-skus-query
+	   (str "SELECT * FROM orders "
+		"JOIN order_lines ON (orders.id = order_lines.order_id) "
+		"JOIN product_variants ON (order_lines.product_variant_id = product_variants.id) "
+		"JOIN product_variant_skus ON (product_variants.id = product_variant_skus.product_variant_id) "
+		"JOIN skus ON (skus.id = product_variant_skus.sku_id) "
+		"JOIN products ON (products.id = product_variants.product_id) "
+		"WHERE (orders.status = 1)"))))
   
   (testing "update-in!"
     (expect [update-or-insert-vals (has-args [:users ["(id = ?)" 1] {:name "Bob"}])


### PR DESCRIPTION
Hi,

I've had a go at fixing the problem we identified at the end of Jan, and worked around, where if you joined tables in the wrong order, then your joins disappeared from the generated sql.  I've had to do this because I got to the point where we could no longer work around the problem.  This identified another problem, where the joins were out of order in the generated sql, and would cause an error.  So I've tried to fix that too.  I'm sure that my code is horrible and will require re-writing.

I've also had a go a back porting this fix to 1.0.x on a different branch (backport-associative-fix-to-1.0.x), since the fix I did on master relied on other changes not on 1.0.1.  I'll create a separate pull request for that branch.

I'd appreciate a 1.0.2 release with this functionality working soon, but until then, we'll just upload a patched version into nexus.

Many thanks,
Ed
