### PR TITLE
Fix return id as meta

### DIFF
--- a/src/clojureql/internal.clj
+++ b/src/clojureql/internal.clj
@@ -1,4 +1,5 @@
 (ns clojureql.internal
+  (:import [java.sql Statement])
   (:require
    [clojure.contrib.sql.internal :as sqlint]
    [clojure.contrib.sql :as csql])
@@ -339,7 +340,7 @@
   [[sql & params :as sql-params] func]
   (when-not (vector? sql-params)
     (throw (Exception. "sql-params must be a vector")))
-  (with-open [stmt (.prepareStatement (:connection sqlint/*db*) sql)]
+  (with-open [stmt (.prepareStatement (:connection sqlint/*db*) sql Statement/RETURN_GENERATED_KEYS)]
     (doseq [[idx v] (map vector (iterate inc 1) params)]
       (.setObject stmt idx v))
     (if-let [fetch-size (-> sqlint/*db* :opts :fetch-size)]
@@ -356,7 +357,7 @@
   open database connection. Each param-group is a seq of values for all of
   the parameters."
   [sql & param-groups]
-  (with-open [stmt (.prepareStatement (:connection sqlint/*db*) sql)]
+  (with-open [stmt (.prepareStatement (:connection sqlint/*db*) sql Statement/RETURN_GENERATED_KEYS)]
     (doseq [param-group param-groups]
       (doseq [[idx v] (map vector (iterate inc 1) param-group)]
         (.setObject stmt idx v))


### PR DESCRIPTION
Mysql threw an SQLException when calling conj! with this message: Generated keys not requested. You need to specify Statement.RETURN_GENERATED_KEYS to Statement.executeUpdate() or Connection.prepareStatement().

So I did as it said.
