### PR TITLE
Remove alias from GROUP BY.

### DIFF
--- a/src/clojureql/core.clj
+++ b/src/clojureql/core.clj
@@ -366,7 +366,9 @@
 
   (grouped [this field]
     ;TODO: We shouldn't call to-fieldlist here, first in the compiler
-    (let [colname (with-meta [(to-fieldlist tname field)] {:prepend true})]
+    (let [colname (with-meta [(to-fieldlist tname
+                                            (map #(if (vector? %) (first %) (identity %))
+                                                 field))] {:prepend true})]
       (assoc this :grouped-by
              (conj (or grouped-by [])
                    (if (seq combinations)

--- a/test/clojureql/test/core.clj
+++ b/test/clojureql/test/core.clj
@@ -200,7 +200,22 @@
          select-country-ids-with-region-count
          (str "SELECT regions.country_id,count(regions.id) AS regions FROM regions GROUP BY regions.country_id")
          select-country-ids-with-spot-count
-         (str "SELECT spots.country_id,count(spots.id) AS spots FROM spots GROUP BY spots.country_id")))
+         (str "SELECT spots.country_id,count(spots.id) AS spots FROM spots GROUP BY spots.country_id")
+         (-> (table :users)
+             (select (where (= :admin true)))
+             (aggregate [[:count/* :as :user_count]] [:country]))
+         (str "SELECT users.country,count(*) AS user_count FROM users "
+              "WHERE (users.admin = true) GROUP BY users.country")
+         (-> (table :users)
+             (select (where (= :admin true)))
+             (aggregate [:count/*] [[:country :as :user_country]]))
+         (str "SELECT users.country AS user_country,count(*) FROM users "
+              "WHERE (users.admin = true) GROUP BY users.country")
+         (-> (table :users)
+             (select (where (= :admin true)))
+             (aggregate [:count/*] [:name [:country :as :user_country]]))
+         (str "SELECT users.name,users.country AS user_country,count(*) FROM users "
+              "WHERE (users.admin = true) GROUP BY users.name,users.country")))
 
   (testing "join with aggregate"
     (let [photo-counts-by-user (-> (table :photos)


### PR DESCRIPTION
Dear ClojureQL team,

This fixes aliases in GROUP BY (see associated tests).

As noted, this is more of a kludge right now, since the function has following todo `We shouldn't call to-fieldlist here, first in the compiler`.

I am more then happy to take a stab at re-factoring the `to-fieldlist`, but would like to talk to someone beforehand (via irc) before I go off in the wrong direction and wasting everyones time.

Regards,

Christian
