### PR TITLE
Let `in` predicate accept any seq

### DIFF
--- a/src/clojureql/predicates.clj
+++ b/src/clojureql/predicates.clj
@@ -84,7 +84,7 @@
       :stmt (conj stmt (format "%s %s (%s)"
                                (nskeyword field)
                                (upper-name op)
-                               (->> (if (vector? (first expr))
+                               (->> (if (coll? (first expr))
                                       (first expr)
                                       expr)
                                     parameterize

--- a/test/clojureql/test/predicates.clj
+++ b/test/clojureql/test/predicates.clj
@@ -37,4 +37,10 @@
        (not* (or* (<* :id 100) (>* :id 101)))
        ["NOT(((id < ?) OR (id > ?)))" [100 101]]
        (not* (or* (=* :id 5) (not* (like :name "frank%"))))
-       ["NOT(((id = ?) OR NOT((name LIKE ?))))" [5 "frank%"]]))
+       ["NOT(((id = ?) OR NOT((name LIKE ?))))" [5 "frank%"]]
+       (in :x [1 2])
+       ["x IN (?,?)" [1 2]]
+       (in :x '(1 2))
+       ["x IN (?,?)" [1 2]]
+       (in :x #{1 2})
+       ["x IN (?,?)" [1 2]]))


### PR DESCRIPTION
I was surprised that when I passed a list into `in`:

```
(-> tbl
    (select (where (in :column a_list))))
```

the compiled SQL only contained the first element of the list.
I dug into the source and found that it was because prefix operators check their arguments with `vector?`.
I changed this to the more general `seq?`, and it seems to work fine for me (both in the REPL, and all of the tests pass when running `cake test`).
