### PR TITLE
Allow use of raw string predicates

### DIFF
--- a/src/clojureql/predicates.clj
+++ b/src/clojureql/predicates.clj
@@ -121,7 +121,9 @@
     (predicate
      (map #(if (qualify? %) (str (to-tablealias (:tname this))
                                  \. %) %)
-          (flatten stmt))
+          (if (string? pred)
+            [pred]
+            (flatten stmt)))
      env
      cols)))
 

--- a/test/clojureql/test/core.clj
+++ b/test/clojureql/test/core.clj
@@ -150,6 +150,12 @@
              (select (where (= :title "Developer"))))
          "SELECT users.* FROM users WHERE (users.id = 5) AND (users.title = Developer)"))
 
+  (testing "String predicates"
+    (are [x y] (= (-> x (compile nil) interpolate-sql) y)
+         (-> (table :users)
+             (select "name = 'Frank'"))
+         "SELECT users.* FROM users WHERE name = 'Frank'"))
+
   (testing "projections"
     (are [x y] (= (-> x (compile nil) interpolate-sql) y)
          (-> (table :users)


### PR DESCRIPTION
Commit 4d323eb introduced a bug by changing a reduce into a map, losing the base case of (str pred) that handled raw string predicates:

https://github.com/LauJensen/clojureql/commit/4d323eb4d6beb8712f5a0e8d84e17091ee704b85#L0L118

This commit adds a test and fixes the bug.
