### PR TITLE
Avoid namespace collisions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Then execute
 
 And import the library into your namespace
 
-    (:use '[clojureql.core :as cql])
+    (:require '[clojureql.core :as cql])
 
 
 Manual


### PR DESCRIPTION
<pre>
user> (use 'clojureql.core)
WARNING: distinct already refers to: #'clojure.core/distinct in namespace: user, being replaced by: #'clojureql.core/distinct
WARNING: conj! already refers to: #'clojure.core/conj! in namespace: user, being replaced by: #'clojureql.core/conj!
WARNING: compile already refers to: #'clojure.core/compile in namespace: user, being replaced by: #'clojureql.core/compile
WARNING: drop already refers to: #'clojure.core/drop in namespace: user, being replaced by: #'clojureql.core/drop
WARNING: take already refers to: #'clojure.core/take in namespace: user, being replaced by: #'clojureql.core/take
WARNING: sort already refers to: #'clojure.core/sort in namespace: user, being replaced by: #'clojureql.core/sort
WARNING: disj! already refers to: #'clojure.core/disj! in namespace: user, being replaced by: #'clojureql.core/disj!
</pre>
