### PR TITLE
Add ordered keys as meta-data to the result-seq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: clojure
+lein: lein
+script: lein test
+jdk:
+  - openjdk7
+  - openjdk6

--- a/src/clojureql/internal.clj
+++ b/src/clojureql/internal.clj
@@ -338,7 +338,7 @@
                             (transient empty)
                             idxs))
                    (rows)))))]
-    (rows)))
+    (with-meta (rows) {:keys keys})))
 
 
 (defn with-results*
@@ -375,7 +375,7 @@
   "When supported by the JDBC driver, returns the generated keys of the latest executed statement"
   (when (supports-generated-keys? (.getConnection stmt))
     (let [ks (.getGeneratedKeys stmt)]
-      {:last-index 
+      {:last-index
        (and
         (.next ks)
         (.getObject ks 1))})))
@@ -490,14 +490,14 @@
       (or alias table-name))))
 
 (defn joins-by-table-alias
-  "given a list of joins return a map of joins 
+  "given a list of joins return a map of joins
    keyed by the join table-alias or,
    in the case of subselects, the subselect table alias"
   [joins]
   (reduce #(let [{[table-name-alias join-on] :data :as join} %2
                  k (join-table-alias table-name-alias)]
-             (assoc %1 k join)) 
-          {} 
+             (assoc %1 k join))
+          {}
           joins))
 
 (defn join-column-names
@@ -518,7 +518,7 @@
       (concat renamed-subselect-col-strs other-col-strs))
     cols))
 
-(defn to-tbl-name 
+(defn to-tbl-name
   "given a join definition, return a table alias
    that the join depends on"
   [{[table-name-alias join-on] :data :as join}]
@@ -528,25 +528,25 @@
        (filter #(not= % (join-table-alias table-name-alias)))
        first))
 
-(defn to-graph-el 
+(defn to-graph-el
   "given a join definition return an edge in the table
    alias dependency graph"
   [m {[table-name-alias join-on] :data :as join}]
   (let [required-table (to-tbl-name join)]
     (assoc m (join-table-alias table-name-alias) required-table)))
 
-(defn add-deps 
+(defn add-deps
   "recursively add dependencies of tbl into a list"
   [map-of-joins edges tbl]
-  (into [(map-of-joins tbl)] (map #(add-deps map-of-joins edges %) 
-                                  (filter #(= tbl (edges %)) 
+  (into [(map-of-joins tbl)] (map #(add-deps map-of-joins edges %)
+                                  (filter #(= tbl (edges %))
                                           (keys edges)))))
 
 (defn flatten-deps
   [map-of-joins edges set-of-root-nodes]
   (filter #(not (nil? %)) (flatten (map #(add-deps map-of-joins edges %) set-of-root-nodes))))
 
-(defn sort-joins 
+(defn sort-joins
   "sort a list of joins into dependency order"
   [joins]
   (let [map-of-joins (joins-by-table-alias joins)

--- a/src/clojureql/internal.clj
+++ b/src/clojureql/internal.clj
@@ -338,7 +338,7 @@
                             (transient empty)
                             idxs))
                    (rows)))))]
-    (with-meta (rows) {:keys keys})))
+    (with-meta (rows) {:column-names keys})))
 
 
 (defn with-results*


### PR DESCRIPTION
Presently there is no way to determine the order of fields retrieved out of any SQL that was executed, because the row data is slotted into a hash-map, and the ordering is lost. I did consider changing this to use an array-map, but this only works up to 16 elements, and in any regard, this is copy-on-write so performance is not great.

Instead, the ordered keys are added as meta data to the result-seq, so they can be extracted out as follows:

``` clojure
  (with-results [res query]
    (let [cols (:column-names (meta res))]
      ...    
```
